### PR TITLE
add rebase timestamp to logs

### DIFF
--- a/contracts/UFragmentsPolicy.sol
+++ b/contracts/UFragmentsPolicy.sol
@@ -31,8 +31,8 @@ contract UFragmentsPolicy is Ownable {
         uint256 indexed epoch,
         uint256 exchangeRate,
         uint256 cpi,
-        int256 requestedSupplyAdjustment
-        uint256 lastRebaseTimestampSec
+        int256 requestedSupplyAdjustment,
+        uint256 timestampSec
     );
 
     UFragments public uFrags;

--- a/contracts/UFragmentsPolicy.sol
+++ b/contracts/UFragmentsPolicy.sol
@@ -32,6 +32,7 @@ contract UFragmentsPolicy is Ownable {
         uint256 exchangeRate,
         uint256 cpi,
         int256 requestedSupplyAdjustment
+        uint256 lastRebaseTimestampSec
     );
 
     UFragments public uFrags;
@@ -113,7 +114,7 @@ contract UFragmentsPolicy is Ownable {
 
         uint256 supplyAfterRebase = uFrags.rebase(epoch, supplyDelta);
         assert(supplyAfterRebase <= MAX_SUPPLY);
-        emit LogRebase(epoch, exchangeRate, cpi, supplyDelta);
+        emit LogRebase(epoch, exchangeRate, cpi, supplyDelta, lastRebaseTimestampSec);
     }
 
     /**


### PR DESCRIPTION
This is going to save all the block calls since we would be able to use the timestamp from here instead of calling all the blocks individually and getting the timestamp from the block.