### PR TITLE
Disabling compiler optimizations 

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -11,8 +11,7 @@ module.exports = {
       version: '0.4.24',
       settings: {
         optimizer: {
-          enabled: true,
-          runs: 1000000
+          enabled: false
         }
       }
     }


### PR DESCRIPTION
Disabling based on Trail of bits recommendation
"In light of the compiler audit released last fall as well as some recent high-severity bugs related to optimization issues, we currently caution against compiling with optimizations enabled unless the risk of potential latent optimizer bugs is carefully weighed against the gas savings optimizations would provide."