### PR TITLE
Test fix

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -59,7 +59,6 @@ run-all-tests "ganacheUnitTest"
 if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]
 then
   run-simulation-tests "ganacheUnitTest"
-  run-all-tests "gethUnitTest"
 fi
 
 exit 0

--- a/test/unit/UFragmentsPolicy.js
+++ b/test/unit/UFragmentsPolicy.js
@@ -436,7 +436,7 @@ contract('UFragmentsPolicy:Rebase', async function (accounts) {
       await uFragmentsPolicy.setRebaseTimingParameters(60, 0, 60);
       await chain.waitForSomeTime(60);
       await uFragmentsPolicy.rebase();
-      await chain.waitForSomeTime(72);
+      await chain.waitForSomeTime(59);
       prevEpoch = await uFragmentsPolicy.epoch.call();
       prevTime = await uFragmentsPolicy.lastRebaseTimestampSec.call();
       await mockExternalData(INITIAL_RATE_60P_MORE, INITIAL_CPI, 1010);


### PR DESCRIPTION
- Dropped running geth tests on the master build. New change requires evm time manipulation not supported on geth.

- Fixed time-dependent flaky test