### PR TITLE
AMPL Pool / Balance Registry

### DIFF
--- a/contracts/AMPLBalanceRegistry.sol
+++ b/contracts/AMPLBalanceRegistry.sol
@@ -1,0 +1,244 @@
+pragma solidity 0.4.24;
+
+import "openzeppelin-contracts/contracts/math/SafeMath.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20Detailed.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+
+contract AMPLBalanceRegistry is ERC20Detailed {
+    using SafeMath for uint256;
+
+    /*
+     * Constants copied from UFragments.sol
+     */
+    uint256 private constant DECIMALS = 9;
+    uint256 private constant MAX_UINT256 = ~uint256(0);
+    uint256 private constant INITIAL_FRAGMENTS_SUPPLY = 50 * 10**6 * 10**DECIMALS;
+    uint256 private constant TOTAL_GONS = MAX_UINT256 - (MAX_UINT256 % INITIAL_FRAGMENTS_SUPPLY);
+
+    address public IERC20 amplToken = 0x0;
+
+    // Denominated in gons
+    mapping (address => uint256) private _balances;
+
+    // Denominated in AMPL
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    // Denominated in gons
+    uint256 private _totalSupply;
+
+    constructor(address amplToken_) public ERC20Detailed("Ampleforth", "AMPL", uint8(DECIMALS)) {
+        amplToken = IERC20(amplToken_);
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return fromGon(_totalSupply);
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return fromGon(_balances[account]);
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for `sender`'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(toGon(amount), "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(toGon(amount));
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Deposits `amount` AMPL and assigns them to `msg.sender`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     */
+    function deposit(uint256 amount) internal virtual {
+        _beforeTokenTransfer(address(0), msg.sender, amount);
+
+        _totalSupply = _totalSupply.add(toGon(amount));
+        _balances[account] = _balances[account].add(toGon(amount));
+
+        amplToken.safeTransferFrom(msg.sender, address(this), amount);
+        emit Transfer(address(0), msg.sender, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     * TODO: come back to this, change to withdraw to msg.sender
+     */
+    function withdraw(uint256 amount) internal virtual {
+        _beforeTokenTransfer(msg.sender, address(0), amount);
+
+        _balances[account] = _balances[account].sub(toGon(amount), "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(toGon(amount));
+        amplToken.safeTransferFrom(address(this), msg.sender, amount);
+        emit Transfer(msg.sender, address(0), amount);
+    }
+
+    // TODO: add a withdrawBalanceDifference? withdrawOtherToken? withdrawEth?
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of `from`'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of `from`'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:using-hooks.adoc[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+
+    function gonsPerAMPL() internal view returns (uint256) {
+        return TOTAL_GONS.div(amplToken.totalSupply());
+    }
+
+    function toGon(uint256 amplValue) internal view returns (uint256) {
+        return amplValue.mul(gonsPerAMPL());
+    }
+
+    function fromGon(uint256 gonValue) internal view returns (uint256) {
+        return gonValue.div(gonsPerAMPL());
+    }
+}


### PR DESCRIPTION
Proof of concept for a simple holder contract that can hold AMPL on behalf of users.

The idea for this is that it will make integrations with AMPL much easier. It's essentially a wrapper token, where users can deposit or withdraw AMPL tokens, and those balances still follow the rebase movements.

Seems like a nice integration piece without the "fixed supply" token we'd throw around earlier.

Still totally untested / uncompiled, but the main functionality should all be there.

We could consider adding deposit(from, to) or withdraw(from, to) style functions as well instead of just the msg.sender versions.