### PR TITLE
Disallow rebase calls from contracts

### DIFF
--- a/contracts/UFragmentsPolicy.sol
+++ b/contracts/UFragmentsPolicy.sol
@@ -83,13 +83,16 @@ contract UFragmentsPolicy is Ownable {
     uint256 private constant MAX_SUPPLY = ~(uint256(1) << 255) / MAX_RATE;
 
     /**
-     * @notice Anyone can call this function to initiate a new rebase operation, provided more than
-     *         the minimum time period has elapsed.
+     * @notice Any EOA address can call this function to initiate a new rebase operation, provided
+     *         more than the minimum time period has elapsed.
+     *         Contracts are guarded from calling, to avoid flash loan attacks on liquidity
+     *         providers.
      * @dev The supply adjustment equals (_totalSupply * DeviationFromTargetRate) / rebaseLag
      *      Where DeviationFromTargetRate is (MarketOracleRate - targetRate) / targetRate
      *      and targetRate is CpiOracleRate / baseCpi
      */
     function rebase() external {
+        require(msg.sender == tx.origin);  // solhint-disable-line avoid-tx-origin
         require(inRebaseWindow());
 
         // This comparison also ensures there is no reentrancy.

--- a/contracts/mocks/RebaseCallerContract.sol
+++ b/contracts/mocks/RebaseCallerContract.sol
@@ -1,0 +1,21 @@
+pragma solidity 0.4.24;
+
+import "../UFragmentsPolicy.sol";
+
+
+contract RebaseCallerContract {
+    UFragmentsPolicy private _policy;
+
+    constructor(address policy) public {
+        _policy = UFragmentsPolicy(policy);
+    }
+
+    function callRebase() public returns (bool) {
+        // Take out a flash loan.
+        // Do something funky...
+        _policy.rebase();  // should fail
+        // pay back flash loan.
+
+        return true;
+    }
+}


### PR DESCRIPTION
Protection from flash loans combined with rebase calls.

This change introduces tx.origin, but only to compare against msg.sender.
It does not use tx.origin for authentication.