### PR TITLE
Add getGlobalAmpleforthEpochAndAMPLSupply

### DIFF
--- a/contracts/UFragmentsPolicy.sol
+++ b/contracts/UFragmentsPolicy.sol
@@ -211,6 +211,20 @@ contract UFragmentsPolicy is Ownable {
     }
 
     /**
+     * @notice A multi-chain AMPL interface method. The Ampleforth monetary policy contract
+     *         on the base-chain and XCAmpleController contracts on the satellite-chains
+     *         implement this method. It returns what the current contract believes to be
+     *         the globalAmpleforthEpoch and globalAMPLSupply.
+     * @return globalAmpleforthEpoch The current epoch number.
+     * @return globalAMPLSupply The total supply at the current epoch.
+     */
+    function getGlobalAmpleforthEpochAndAMPLSupply() external view returns (uint256, uint256) {
+        uint256 globalAmpleforthEpoch = epoch;
+        uint256 globalAMPLSupply = uFrags.totalSupply();
+        return (globalAmpleforthEpoch, globalAMPLSupply);
+    }
+
+    /**
      * @dev ZOS upgradable contract initialization method.
      *      It is called at the time of contract creation to invoke parent class initializers and
      *      initialize the contract's state variables.

--- a/contracts/UFragmentsPolicy.sol
+++ b/contracts/UFragmentsPolicy.sol
@@ -213,15 +213,14 @@ contract UFragmentsPolicy is Ownable {
     /**
      * @notice A multi-chain AMPL interface method. The Ampleforth monetary policy contract
      *         on the base-chain and XCAmpleController contracts on the satellite-chains
-     *         implement this method. It returns what the current contract believes to be
+     *         implement this method. It atomically returns two values:
+     *         what the current contract believes to be,
      *         the globalAmpleforthEpoch and globalAMPLSupply.
      * @return globalAmpleforthEpoch The current epoch number.
      * @return globalAMPLSupply The total supply at the current epoch.
      */
     function getGlobalAmpleforthEpochAndAMPLSupply() external view returns (uint256, uint256) {
-        uint256 globalAmpleforthEpoch = epoch;
-        uint256 globalAMPLSupply = uFrags.totalSupply();
-        return (globalAmpleforthEpoch, globalAMPLSupply);
+        return (epoch, uFrags.totalSupply());
     }
 
     /**

--- a/test/unit/UFragmentsPolicy.ts
+++ b/test/unit/UFragmentsPolicy.ts
@@ -164,6 +164,11 @@ describe('UFragmentsPolicy:initialize', async function () {
     it('epoch', async function () {
       expect(await uFragmentsPolicy.epoch()).to.eq(0)
     })
+    it('getGlobalAmpleforthEpochAndAMPLSupply', async function () {
+      const r = await uFragmentsPolicy.getGlobalAmpleforthEpochAndAMPLSupply()
+      expect(r[0]).to.eq(0)
+      expect(r[1]).to.eq(0)
+    })
     it('rebaseWindowOffsetSec', async function () {
       expect(await uFragmentsPolicy.rebaseWindowOffsetSec()).to.eq(72000)
     })
@@ -826,6 +831,13 @@ describe('UFragmentsPolicy:Rebase', async function () {
     it('should increment epoch', async function () {
       await uFragmentsPolicy.connect(orchestrator).rebase()
       expect(await uFragmentsPolicy.epoch()).to.eq(prevEpoch.add(1))
+    })
+
+    it('should update getGlobalAmpleforthEpochAndAMPLSupply', async function () {
+      await uFragmentsPolicy.connect(orchestrator).rebase()
+      const r = await uFragmentsPolicy.getGlobalAmpleforthEpochAndAMPLSupply()
+      expect(r[0]).to.eq(prevEpoch.add(1))
+      expect(r[1]).to.eq('1010')
     })
 
     it('should update lastRebaseTimestamp', async function () {


### PR DESCRIPTION
Added a getter on the Policy contract which returns the `globalAmpleforthEpoch` and `globalAMPLSupply`. The MonetaryPolicy (on the base chain) and the XCAmpleController on the satellite chains will implement this method.

When rebase is propagated between chains, its these 2 values which are transmitted. The method allows consumers to read both values atomically.  


fixes #188
