### PR TITLE
Adding truffle config back

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -1,0 +1,15 @@
+// NOTE: this file is required by our internal deployment script uFragments-eth-integration
+// which still works with truffle
+// This can be removed once we completely transition to the new hardhat workflow
+module.exports = {
+  compilers: {
+    solc: {
+      version: '0.4.24',
+      settings: {
+        optimizer: {
+          enabled: false
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
Adding truffle config file back as its used by out internal deployment script, and not having this file breaks our current setup.

Can remove once we move completely to hardhat