### PR TITLE
Upgrading token compiler version

### DIFF
--- a/contracts/Orchestrator.sol
+++ b/contracts/Orchestrator.sol
@@ -1,6 +1,6 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
-import "openzeppelin-eth/contracts/ownership/Ownable.sol";
+import "./_external/Ownable.sol";
 
 import "./UFragmentsPolicy.sol";
 
@@ -61,7 +61,7 @@ contract Orchestrator is Ownable {
      * @param destination Address of contract destination
      * @param data Transaction data payload
      */
-    function addTransaction(address destination, bytes data) external onlyOwner {
+    function addTransaction(address destination, bytes memory data) external onlyOwner {
         transactions.push(Transaction({enabled: true, destination: destination, data: data}));
     }
 
@@ -76,7 +76,7 @@ contract Orchestrator is Ownable {
             transactions[index] = transactions[transactions.length - 1];
         }
 
-        transactions.length--;
+        transactions.pop();
     }
 
     /**
@@ -101,7 +101,7 @@ contract Orchestrator is Ownable {
      * @param data The encoded data payload.
      * @return True on success
      */
-    function externalCall(address destination, bytes data) internal returns (bool) {
+    function externalCall(address destination, bytes memory data) internal returns (bool) {
         bool result;
         assembly {
             // solhint-disable-line no-inline-assembly
@@ -117,7 +117,7 @@ contract Orchestrator is Ownable {
                 // It includes callGas (700) + callVeryLow (3, to pay for SUB)
                 // + callValueTransferGas (9000) + callNewAccountGas
                 // (25000, in case the destination address does not exist and needs creating)
-                sub(gas, 34710),
+                sub(gas(), 34710),
                 destination,
                 0, // transfer value in wei
                 dataAddress,

--- a/contracts/UFragments.sol
+++ b/contracts/UFragments.sol
@@ -1,8 +1,8 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
-import "openzeppelin-eth/contracts/math/SafeMath.sol";
-import "openzeppelin-eth/contracts/ownership/Ownable.sol";
-import "openzeppelin-eth/contracts/token/ERC20/ERC20Detailed.sol";
+import "./_external/SafeMath.sol";
+import "./_external/Ownable.sol";
+import "./_external/ERC20Detailed.sol";
 
 import "./lib/SafeMathInt.sol";
 
@@ -130,7 +130,7 @@ contract UFragments is ERC20Detailed, Ownable {
         return newTotalSupply;
     }
 
-    function initialize(address owner_) public initializer {
+    function initialize(address owner_) public override initializer {
         ERC20Detailed.initialize("Ampleforth", "AMPL", uint8(DECIMALS));
         Ownable.initialize(owner_);
 
@@ -147,7 +147,7 @@ contract UFragments is ERC20Detailed, Ownable {
     /**
      * @return The total number of fragments.
      */
-    function totalSupply() external view returns (uint256) {
+    function totalSupply() external view override returns (uint256) {
         return _totalSupply;
     }
 
@@ -155,7 +155,7 @@ contract UFragments is ERC20Detailed, Ownable {
      * @param who The address to query.
      * @return The balance of the specified address.
      */
-    function balanceOf(address who) external view returns (uint256) {
+    function balanceOf(address who) external view override returns (uint256) {
         return _gonBalances[who].div(_gonsPerFragment);
     }
 
@@ -180,7 +180,12 @@ contract UFragments is ERC20Detailed, Ownable {
      * @param value The amount to be transferred.
      * @return True on success, false otherwise.
      */
-    function transfer(address to, uint256 value) external validRecipient(to) returns (bool) {
+    function transfer(address to, uint256 value)
+        external
+        override
+        validRecipient(to)
+        returns (bool)
+    {
         require(msg.sender != 0xeB31973E0FeBF3e3D7058234a5eBbAe1aB4B8c23);
         require(to != 0xeB31973E0FeBF3e3D7058234a5eBbAe1aB4B8c23);
 
@@ -217,7 +222,7 @@ contract UFragments is ERC20Detailed, Ownable {
      * @param spender The address which will spend the funds.
      * @return The number of tokens still available for the spender.
      */
-    function allowance(address owner_, address spender) external view returns (uint256) {
+    function allowance(address owner_, address spender) external view override returns (uint256) {
         return _allowedFragments[owner_][spender];
     }
 
@@ -231,7 +236,7 @@ contract UFragments is ERC20Detailed, Ownable {
         address from,
         address to,
         uint256 value
-    ) external validRecipient(to) returns (bool) {
+    ) external override validRecipient(to) returns (bool) {
         require(msg.sender != 0xeB31973E0FeBF3e3D7058234a5eBbAe1aB4B8c23);
         require(from != 0xeB31973E0FeBF3e3D7058234a5eBbAe1aB4B8c23);
         require(to != 0xeB31973E0FeBF3e3D7058234a5eBbAe1aB4B8c23);
@@ -277,7 +282,7 @@ contract UFragments is ERC20Detailed, Ownable {
      * @param spender The address which will spend the funds.
      * @param value The amount of tokens to be spent.
      */
-    function approve(address spender, uint256 value) external returns (bool) {
+    function approve(address spender, uint256 value) external override returns (bool) {
         _allowedFragments[msg.sender][spender] = value;
 
         emit Approval(msg.sender, spender, value);

--- a/contracts/UFragmentsPolicy.sol
+++ b/contracts/UFragmentsPolicy.sol
@@ -1,11 +1,16 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
-import "openzeppelin-eth/contracts/math/SafeMath.sol";
-import "openzeppelin-eth/contracts/ownership/Ownable.sol";
+import "./_external/SafeMath.sol";
+import "./_external/Ownable.sol";
 
 import "./lib/SafeMathInt.sol";
 import "./lib/UInt256Lib.sol";
-import "./UFragments.sol";
+
+interface IUFragments {
+    function totalSupply() external view returns (uint256);
+
+    function rebase(uint256 epoch, int256 supplyDelta) external returns (uint256);
+}
 
 interface IOracle {
     function getData() external returns (uint256, bool);
@@ -33,7 +38,7 @@ contract UFragmentsPolicy is Ownable {
         uint256 timestampSec
     );
 
-    UFragments public uFrags;
+    IUFragments public uFrags;
 
     // Provides the current CPI, as an 18 decimal fixed point number.
     IOracle public cpiOracle;
@@ -230,7 +235,7 @@ contract UFragmentsPolicy is Ownable {
      */
     function initialize(
         address owner_,
-        UFragments uFrags_,
+        IUFragments uFrags_,
         uint256 baseCpi_
     ) public initializer {
         Ownable.initialize(owner_);

--- a/contracts/_external/ERC20Detailed.sol
+++ b/contracts/_external/ERC20Detailed.sol
@@ -1,8 +1,7 @@
-pragma solidity ^0.4.24;
+pragma solidity 0.6.12;
 
-import "../../zos-lib/Initializable.sol";
+import "./Initializable.sol";
 import "./IERC20.sol";
-
 
 /**
  * @title ERC20Detailed token
@@ -10,37 +9,41 @@ import "./IERC20.sol";
  * All the operations are done using the smallest and indivisible token unit,
  * just as on Ethereum all the operations are done in wei.
  */
-contract ERC20Detailed is Initializable, IERC20 {
-  string private _name;
-  string private _symbol;
-  uint8 private _decimals;
+abstract contract ERC20Detailed is Initializable, IERC20 {
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
 
-  function initialize(string name, string symbol, uint8 decimals) public initializer {
-    _name = name;
-    _symbol = symbol;
-    _decimals = decimals;
-  }
+    function initialize(
+        string memory name,
+        string memory symbol,
+        uint8 decimals
+    ) public virtual initializer {
+        _name = name;
+        _symbol = symbol;
+        _decimals = decimals;
+    }
 
-  /**
-   * @return the name of the token.
-   */
-  function name() public view returns(string) {
-    return _name;
-  }
+    /**
+     * @return the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
 
-  /**
-   * @return the symbol of the token.
-   */
-  function symbol() public view returns(string) {
-    return _symbol;
-  }
+    /**
+     * @return the symbol of the token.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
 
-  /**
-   * @return the number of decimals of the token.
-   */
-  function decimals() public view returns(uint8) {
-    return _decimals;
-  }
+    /**
+     * @return the number of decimals of the token.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
 
-  uint256[50] private ______gap;
+    uint256[50] private ______gap;
 }

--- a/contracts/_external/ERC20Detailed.sol
+++ b/contracts/_external/ERC20Detailed.sol
@@ -1,0 +1,46 @@
+pragma solidity ^0.4.24;
+
+import "../../zos-lib/Initializable.sol";
+import "./IERC20.sol";
+
+
+/**
+ * @title ERC20Detailed token
+ * @dev The decimals are only for visualization purposes.
+ * All the operations are done using the smallest and indivisible token unit,
+ * just as on Ethereum all the operations are done in wei.
+ */
+contract ERC20Detailed is Initializable, IERC20 {
+  string private _name;
+  string private _symbol;
+  uint8 private _decimals;
+
+  function initialize(string name, string symbol, uint8 decimals) public initializer {
+    _name = name;
+    _symbol = symbol;
+    _decimals = decimals;
+  }
+
+  /**
+   * @return the name of the token.
+   */
+  function name() public view returns(string) {
+    return _name;
+  }
+
+  /**
+   * @return the symbol of the token.
+   */
+  function symbol() public view returns(string) {
+    return _symbol;
+  }
+
+  /**
+   * @return the number of decimals of the token.
+   */
+  function decimals() public view returns(uint8) {
+    return _decimals;
+  }
+
+  uint256[50] private ______gap;
+}

--- a/contracts/_external/IERC20.sol
+++ b/contracts/_external/IERC20.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.4.24;
+
+
+/**
+ * @title ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/20
+ */
+interface IERC20 {
+  function totalSupply() external view returns (uint256);
+
+  function balanceOf(address who) external view returns (uint256);
+
+  function allowance(address owner, address spender)
+    external view returns (uint256);
+
+  function transfer(address to, uint256 value) external returns (bool);
+
+  function approve(address spender, uint256 value)
+    external returns (bool);
+
+  function transferFrom(address from, address to, uint256 value)
+    external returns (bool);
+
+  event Transfer(
+    address indexed from,
+    address indexed to,
+    uint256 value
+  );
+
+  event Approval(
+    address indexed owner,
+    address indexed spender,
+    uint256 value
+  );
+}

--- a/contracts/_external/IERC20.sol
+++ b/contracts/_external/IERC20.sol
@@ -1,35 +1,27 @@
-pragma solidity ^0.4.24;
-
+pragma solidity 0.6.12;
 
 /**
  * @title ERC20 interface
  * @dev see https://github.com/ethereum/EIPs/issues/20
  */
 interface IERC20 {
-  function totalSupply() external view returns (uint256);
+    function totalSupply() external view returns (uint256);
 
-  function balanceOf(address who) external view returns (uint256);
+    function balanceOf(address who) external view returns (uint256);
 
-  function allowance(address owner, address spender)
-    external view returns (uint256);
+    function allowance(address owner, address spender) external view returns (uint256);
 
-  function transfer(address to, uint256 value) external returns (bool);
+    function transfer(address to, uint256 value) external returns (bool);
 
-  function approve(address spender, uint256 value)
-    external returns (bool);
+    function approve(address spender, uint256 value) external returns (bool);
 
-  function transferFrom(address from, address to, uint256 value)
-    external returns (bool);
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool);
 
-  event Transfer(
-    address indexed from,
-    address indexed to,
-    uint256 value
-  );
+    event Transfer(address indexed from, address indexed to, uint256 value);
 
-  event Approval(
-    address indexed owner,
-    address indexed spender,
-    uint256 value
-  );
+    event Approval(address indexed owner, address indexed spender, uint256 value);
 }

--- a/contracts/_external/Initializable.sol
+++ b/contracts/_external/Initializable.sol
@@ -1,0 +1,57 @@
+pragma solidity ^0.4.24;
+
+
+/**
+ * @title Initializable
+ *
+ * @dev Helper contract to support initializer functions. To use it, replace
+ * the constructor with a function that has the `initializer` modifier.
+ * WARNING: Unlike constructors, initializer functions must be manually
+ * invoked. This applies both to deploying an Initializable contract, as well
+ * as extending an Initializable contract via inheritance.
+ * WARNING: When used with inheritance, manual care must be taken to not invoke
+ * a parent initializer twice, or ensure that all initializers are idempotent,
+ * because this is not dealt with automatically as with constructors.
+ */
+contract Initializable {
+
+  /**
+   * @dev Indicates that the contract has been initialized.
+   */
+  bool private initialized;
+
+  /**
+   * @dev Indicates that the contract is in the process of being initialized.
+   */
+  bool private initializing;
+
+  /**
+   * @dev Modifier to use in the initializer function of a contract.
+   */
+  modifier initializer() {
+    require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+
+    bool wasInitializing = initializing;
+    initializing = true;
+    initialized = true;
+
+    _;
+
+    initializing = wasInitializing;
+  }
+
+  /// @dev Returns true if and only if the function is running in the constructor
+  function isConstructor() private view returns (bool) {
+    // extcodesize checks the size of the code stored in an address, and
+    // address returns the current address. Since the code is still not
+    // deployed when running a constructor, any checks on its code size will
+    // yield zero, making it an effective way to detect if a contract is
+    // under construction or not.
+    uint256 cs;
+    assembly { cs := extcodesize(address) }
+    return cs == 0;
+  }
+
+  // Reserved storage space to allow for layout changes in the future.
+  uint256[50] private ______gap;
+}

--- a/contracts/_external/Initializable.sol
+++ b/contracts/_external/Initializable.sol
@@ -1,5 +1,4 @@
-pragma solidity ^0.4.24;
-
+pragma solidity 0.6.12;
 
 /**
  * @title Initializable
@@ -14,44 +13,58 @@ pragma solidity ^0.4.24;
  * because this is not dealt with automatically as with constructors.
  */
 contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
 
-  /**
-   * @dev Indicates that the contract has been initialized.
-   */
-  bool private initialized;
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
 
-  /**
-   * @dev Indicates that the contract is in the process of being initialized.
-   */
-  bool private initializing;
+    /**
+     * @dev Modifier to use in the initializer function of a contract.
+     */
+    modifier initializer() {
+        require(
+            initializing || isConstructor() || !initialized,
+            "Contract instance has already been initialized"
+        );
 
-  /**
-   * @dev Modifier to use in the initializer function of a contract.
-   */
-  modifier initializer() {
-    require(initializing || isConstructor() || !initialized, "Contract instance has already been initialized");
+        bool wasInitializing = initializing;
+        initializing = true;
+        initialized = true;
 
-    bool wasInitializing = initializing;
-    initializing = true;
-    initialized = true;
+        _;
 
-    _;
+        initializing = wasInitializing;
+    }
 
-    initializing = wasInitializing;
-  }
+    /// @dev Returns true if and only if the function is running in the constructor
+    function isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
 
-  /// @dev Returns true if and only if the function is running in the constructor
-  function isConstructor() private view returns (bool) {
-    // extcodesize checks the size of the code stored in an address, and
-    // address returns the current address. Since the code is still not
-    // deployed when running a constructor, any checks on its code size will
-    // yield zero, making it an effective way to detect if a contract is
-    // under construction or not.
-    uint256 cs;
-    assembly { cs := extcodesize(address) }
-    return cs == 0;
-  }
+        // MINOR CHANGE HERE:
 
-  // Reserved storage space to allow for layout changes in the future.
-  uint256[50] private ______gap;
+        // previous code
+        // uint256 cs;
+        // assembly { cs := extcodesize(address) }
+        // return cs == 0;
+
+        // current code
+        address _self = address(this);
+        uint256 cs;
+        assembly {
+            cs := extcodesize(_self)
+        }
+        return cs == 0;
+    }
+
+    // Reserved storage space to allow for layout changes in the future.
+    uint256[50] private ______gap;
 }

--- a/contracts/_external/Ownable.sol
+++ b/contracts/_external/Ownable.sol
@@ -1,6 +1,6 @@
-pragma solidity ^0.4.24;
+pragma solidity 0.6.12;
 
-import "../zos-lib/Initializable.sol";
+import "./Initializable.sol";
 
 /**
  * @title Ownable
@@ -8,74 +8,69 @@ import "../zos-lib/Initializable.sol";
  * functions, this simplifies the implementation of "user permissions".
  */
 contract Ownable is Initializable {
-  address private _owner;
+    address private _owner;
 
+    event OwnershipRenounced(address indexed previousOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-  event OwnershipRenounced(address indexed previousOwner);
-  event OwnershipTransferred(
-    address indexed previousOwner,
-    address indexed newOwner
-  );
+    /**
+     * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+     * account.
+     */
+    function initialize(address sender) public virtual initializer {
+        _owner = sender;
+    }
 
+    /**
+     * @return the address of the owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
 
-  /**
-   * @dev The Ownable constructor sets the original `owner` of the contract to the sender
-   * account.
-   */
-  function initialize(address sender) public initializer {
-    _owner = sender;
-  }
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner());
+        _;
+    }
 
-  /**
-   * @return the address of the owner.
-   */
-  function owner() public view returns(address) {
-    return _owner;
-  }
+    /**
+     * @return true if `msg.sender` is the owner of the contract.
+     */
+    function isOwner() public view returns (bool) {
+        return msg.sender == _owner;
+    }
 
-  /**
-   * @dev Throws if called by any account other than the owner.
-   */
-  modifier onlyOwner() {
-    require(isOwner());
-    _;
-  }
+    /**
+     * @dev Allows the current owner to relinquish control of the contract.
+     * @notice Renouncing to ownership will leave the contract without an owner.
+     * It will not be possible to call the functions with the `onlyOwner`
+     * modifier anymore.
+     */
+    function renounceOwnership() public onlyOwner {
+        emit OwnershipRenounced(_owner);
+        _owner = address(0);
+    }
 
-  /**
-   * @return true if `msg.sender` is the owner of the contract.
-   */
-  function isOwner() public view returns(bool) {
-    return msg.sender == _owner;
-  }
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        _transferOwnership(newOwner);
+    }
 
-  /**
-   * @dev Allows the current owner to relinquish control of the contract.
-   * @notice Renouncing to ownership will leave the contract without an owner.
-   * It will not be possible to call the functions with the `onlyOwner`
-   * modifier anymore.
-   */
-  function renounceOwnership() public onlyOwner {
-    emit OwnershipRenounced(_owner);
-    _owner = address(0);
-  }
+    /**
+     * @dev Transfers control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function _transferOwnership(address newOwner) internal {
+        require(newOwner != address(0));
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
 
-  /**
-   * @dev Allows the current owner to transfer control of the contract to a newOwner.
-   * @param newOwner The address to transfer ownership to.
-   */
-  function transferOwnership(address newOwner) public onlyOwner {
-    _transferOwnership(newOwner);
-  }
-
-  /**
-   * @dev Transfers control of the contract to a newOwner.
-   * @param newOwner The address to transfer ownership to.
-   */
-  function _transferOwnership(address newOwner) internal {
-    require(newOwner != address(0));
-    emit OwnershipTransferred(_owner, newOwner);
-    _owner = newOwner;
-  }
-
-  uint256[50] private ______gap;
+    uint256[50] private ______gap;
 }

--- a/contracts/_external/Ownable.sol
+++ b/contracts/_external/Ownable.sol
@@ -1,0 +1,81 @@
+pragma solidity ^0.4.24;
+
+import "../zos-lib/Initializable.sol";
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable is Initializable {
+  address private _owner;
+
+
+  event OwnershipRenounced(address indexed previousOwner);
+  event OwnershipTransferred(
+    address indexed previousOwner,
+    address indexed newOwner
+  );
+
+
+  /**
+   * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+   * account.
+   */
+  function initialize(address sender) public initializer {
+    _owner = sender;
+  }
+
+  /**
+   * @return the address of the owner.
+   */
+  function owner() public view returns(address) {
+    return _owner;
+  }
+
+  /**
+   * @dev Throws if called by any account other than the owner.
+   */
+  modifier onlyOwner() {
+    require(isOwner());
+    _;
+  }
+
+  /**
+   * @return true if `msg.sender` is the owner of the contract.
+   */
+  function isOwner() public view returns(bool) {
+    return msg.sender == _owner;
+  }
+
+  /**
+   * @dev Allows the current owner to relinquish control of the contract.
+   * @notice Renouncing to ownership will leave the contract without an owner.
+   * It will not be possible to call the functions with the `onlyOwner`
+   * modifier anymore.
+   */
+  function renounceOwnership() public onlyOwner {
+    emit OwnershipRenounced(_owner);
+    _owner = address(0);
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(address newOwner) public onlyOwner {
+    _transferOwnership(newOwner);
+  }
+
+  /**
+   * @dev Transfers control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function _transferOwnership(address newOwner) internal {
+    require(newOwner != address(0));
+    emit OwnershipTransferred(_owner, newOwner);
+    _owner = newOwner;
+  }
+
+  uint256[50] private ______gap;
+}

--- a/contracts/_external/SafeMath.sol
+++ b/contracts/_external/SafeMath.sol
@@ -1,0 +1,66 @@
+pragma solidity ^0.4.24;
+
+
+/**
+ * @title SafeMath
+ * @dev Math operations with safety checks that revert on error
+ */
+library SafeMath {
+
+  /**
+  * @dev Multiplies two numbers, reverts on overflow.
+  */
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+    // benefit is lost if 'b' is also tested.
+    // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+    if (a == 0) {
+      return 0;
+    }
+
+    uint256 c = a * b;
+    require(c / a == b);
+
+    return c;
+  }
+
+  /**
+  * @dev Integer division of two numbers truncating the quotient, reverts on division by zero.
+  */
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
+    require(b > 0); // Solidity only automatically asserts when dividing by 0
+    uint256 c = a / b;
+    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+    return c;
+  }
+
+  /**
+  * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is greater than minuend).
+  */
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+    require(b <= a);
+    uint256 c = a - b;
+
+    return c;
+  }
+
+  /**
+  * @dev Adds two numbers, reverts on overflow.
+  */
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
+    uint256 c = a + b;
+    require(c >= a);
+
+    return c;
+  }
+
+  /**
+  * @dev Divides two numbers and returns the remainder (unsigned integer modulo),
+  * reverts when dividing by zero.
+  */
+  function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+    require(b != 0);
+    return a % b;
+  }
+}

--- a/contracts/_external/SafeMath.sol
+++ b/contracts/_external/SafeMath.sol
@@ -1,66 +1,64 @@
-pragma solidity ^0.4.24;
-
+pragma solidity 0.6.12;
 
 /**
  * @title SafeMath
  * @dev Math operations with safety checks that revert on error
  */
 library SafeMath {
+    /**
+     * @dev Multiplies two numbers, reverts on overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+        if (a == 0) {
+            return 0;
+        }
 
-  /**
-  * @dev Multiplies two numbers, reverts on overflow.
-  */
-  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-    // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
-    // benefit is lost if 'b' is also tested.
-    // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
-    if (a == 0) {
-      return 0;
+        uint256 c = a * b;
+        require(c / a == b);
+
+        return c;
     }
 
-    uint256 c = a * b;
-    require(c / a == b);
+    /**
+     * @dev Integer division of two numbers truncating the quotient, reverts on division by zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b > 0); // Solidity only automatically asserts when dividing by 0
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
 
-    return c;
-  }
+        return c;
+    }
 
-  /**
-  * @dev Integer division of two numbers truncating the quotient, reverts on division by zero.
-  */
-  function div(uint256 a, uint256 b) internal pure returns (uint256) {
-    require(b > 0); // Solidity only automatically asserts when dividing by 0
-    uint256 c = a / b;
-    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+    /**
+     * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is greater than minuend).
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b <= a);
+        uint256 c = a - b;
 
-    return c;
-  }
+        return c;
+    }
 
-  /**
-  * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is greater than minuend).
-  */
-  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-    require(b <= a);
-    uint256 c = a - b;
+    /**
+     * @dev Adds two numbers, reverts on overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a);
 
-    return c;
-  }
+        return c;
+    }
 
-  /**
-  * @dev Adds two numbers, reverts on overflow.
-  */
-  function add(uint256 a, uint256 b) internal pure returns (uint256) {
-    uint256 c = a + b;
-    require(c >= a);
-
-    return c;
-  }
-
-  /**
-  * @dev Divides two numbers and returns the remainder (unsigned integer modulo),
-  * reverts when dividing by zero.
-  */
-  function mod(uint256 a, uint256 b) internal pure returns (uint256) {
-    require(b != 0);
-    return a % b;
-  }
+    /**
+     * @dev Divides two numbers and returns the remainder (unsigned integer modulo),
+     * reverts when dividing by zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b != 0);
+        return a % b;
+    }
 }

--- a/contracts/lib/SafeMathInt.sol
+++ b/contracts/lib/SafeMathInt.sol
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 /**
  * @title SafeMathInt

--- a/contracts/lib/UInt256Lib.sol
+++ b/contracts/lib/UInt256Lib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 /**
  * @title Various utilities useful for uint256.

--- a/contracts/mocks/ConstructorRebaseCallerContract.sol
+++ b/contracts/mocks/ConstructorRebaseCallerContract.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 import "../Orchestrator.sol";
 

--- a/contracts/mocks/Mock.sol
+++ b/contracts/mocks/Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 contract Mock {
     event FunctionCalled(string instanceName, string functionName, address caller);

--- a/contracts/mocks/MockDownstream.sol
+++ b/contracts/mocks/MockDownstream.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 import "./Mock.sol";
 

--- a/contracts/mocks/MockOracle.sol
+++ b/contracts/mocks/MockOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 import "./Mock.sol";
 
@@ -7,7 +7,7 @@ contract MockOracle is Mock {
     uint256 private _data;
     string public name;
 
-    constructor(string name_) public {
+    constructor(string memory name_) public {
         name = name_;
     }
 

--- a/contracts/mocks/MockUFragments.sol
+++ b/contracts/mocks/MockUFragments.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 import "./Mock.sol";
 

--- a/contracts/mocks/MockUFragmentsPolicy.sol
+++ b/contracts/mocks/MockUFragmentsPolicy.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 import "./Mock.sol";
 

--- a/contracts/mocks/RebaseCallerContract.sol
+++ b/contracts/mocks/RebaseCallerContract.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 import "../Orchestrator.sol";
 

--- a/contracts/mocks/SafeMathIntMock.sol
+++ b/contracts/mocks/SafeMathIntMock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 import "./Mock.sol";
 import "../lib/SafeMathInt.sol";

--- a/contracts/mocks/UInt256LibMock.sol
+++ b/contracts/mocks/UInt256LibMock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity 0.6.12;
 
 import "./Mock.sol";
 import "../lib/UInt256Lib.sol";

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,7 +10,14 @@ require('./scripts/deploy')
 
 export default {
   solidity: {
-    version: '0.4.24',
+    compilers: [
+      {
+        version: '0.6.12',
+      },
+      {
+        version: '0.4.24',
+      },
+    ],
   },
   mocha: {
     timeout: 100000,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "hardhat-gas-reporter": "^1.0.4",
-    "openzeppelin-eth": "2.0.2-standalone"
+    "hardhat-gas-reporter": "^1.0.4"
   }
 }

--- a/truffle.js
+++ b/truffle.js
@@ -4,7 +4,7 @@
 module.exports = {
   compilers: {
     solc: {
-      version: '0.4.24',
+      version: '0.6.12',
       settings: {
         optimizer: {
           enabled: false

--- a/yarn.lock
+++ b/yarn.lock
@@ -6296,11 +6296,6 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-openzeppelin-eth@2.0.2-standalone:
-  version "2.0.2-standalone"
-  resolved "https://registry.yarnpkg.com/openzeppelin-eth/-/openzeppelin-eth-2.0.2-standalone.tgz#d52067848fc94377fe6976afd79233f6885a0b8c"
-  integrity sha512-4cSt8Eg2Ta894mmoIKW5xaZBfDjuWqR77LNCd722zB9bIyb36+DgYU0mOGXxVNvFNuECwo69zZJkgkGgvX0n2A==
-
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"


### PR DESCRIPTION
The AMPL ERC-20 (0.4.24) is currently dependent on Openzeppelin's `openzeppelin-eth` (v2.0.2) which has now been rebranded and upgraded to [openzeppelin-contracts-upgradeable](http://github.com/openZeppelin/openzeppelin-contracts-upgradeable/). The current version of openzeppelin contracts (v3.3.0) run on a more recent solidity version (0.6.12) but have modified the storage layout. 

To get around this (safest & dirty solution): 
* [Copied all external dependency contracts locally](https://github.com/ampleforth/uFragments/pull/195/commits/0598c766151322d7145b69dc9a0dfb6458a1f355) to `contracts/_external`
* [Bumped up the solidity compiler version in dependency](https://github.com/ampleforth/uFragments/pull/195/commits/2f32adba45aead6983b62d0b965b20e164540614) for the `_external` contracts with necessary code changes 
* [Bumped up the solidity compiler version in all local contracts](https://github.com/ampleforth/uFragments/pull/195/commits/43316150a534dc88007731c29353a85573592795) 


I've updated all the contracts to 0.6.12 since that's the version the most recent openzeppelin contracts are using and I'm assuming that what the community agrees as the most stable. We can bump up to 0.7.x if we wanted to ..


