### PR TITLE
Fixed variable visibility

### DIFF
--- a/contracts/UFragmentsPolicy.sol
+++ b/contracts/UFragmentsPolicy.sol
@@ -83,7 +83,7 @@ contract UFragmentsPolicy is Ownable {
     // Both are 18 decimals fixed point numbers.
     uint256 private constant MAX_RATE = 10**6 * 10**DECIMALS;
     // MAX_SUPPLY = MAX_INT256 / MAX_RATE
-    uint256 public constant MAX_SUPPLY = uint256(type(int256).max) / MAX_RATE;
+    uint256 private constant MAX_SUPPLY = uint256(type(int256).max) / MAX_RATE;
 
     // This module orchestrates the rebase execution and downstream notification.
     address public orchestrator;


### PR DESCRIPTION
Making MAX_SUPPLY variable private (as it was before)
https://github.com/ampleforth/uFragments/pull/193/files/212d341f03cd16c4ec50685c788e1dd807eeeded#diff-e22e448df35c045d975f17bf0a3b10a338128bf0147d6a92cc70d20de6576a49L83