### PR TITLE
Update inline documentation to document Orchestrator's revert

### DIFF
--- a/contracts/Orchestrator.sol
+++ b/contracts/Orchestrator.sol
@@ -36,8 +36,8 @@ contract Orchestrator is Ownable {
      *         The Orchestrator calls rebase on the policy and notifies downstream applications.
      *         Contracts are guarded from calling, to avoid flash loan attacks on liquidity
      *         providers.
-     *         If a transaction in the transaction list reverts, it is swallowed and the remaining
-     *         transactions are executed.
+     *         If a transaction in the transaction list fails, Orchestrator will stop execution
+     *         and revert to prevent a gas underprice attack.
      */
     function rebase() external {
         require(msg.sender == tx.origin); // solhint-disable-line avoid-tx-origin


### PR DESCRIPTION
## Overview
Based on one of the help wanted issues [here](https://github.com/ampleforth/uFragments/issues/192), I updated the inline documentation to reflect the [patched change](https://github.com/ampleforth/uFragments/pull/153/). 

Currently if any of the transactions failed, the rebase function will ignore the failed transaction and continue with other transactions. However with the added revert call, the Orchestrator will revert the state changes and return a `Transaction failed` message.

## Reviewers
@nithinkrishna 