### PR TITLE
Replace custom external call with native solidity .call

### DIFF
--- a/contracts/Orchestrator.sol
+++ b/contracts/Orchestrator.sol
@@ -47,9 +47,8 @@ contract Orchestrator is Ownable {
         for (uint256 i = 0; i < transactions.length; i++) {
             Transaction storage t = transactions[i];
             if (t.enabled) {
-                (bool result, bytes memory reason) = t.destination.call(t.data);
+                (bool result, ) = t.destination.call(t.data);
                 if (!result) {
-                    emit TransactionFailed(t.destination, i, t.data);
                     revert("Transaction Failed");
                 }
             }

--- a/contracts/Orchestrator.sol
+++ b/contracts/Orchestrator.sol
@@ -47,7 +47,7 @@ contract Orchestrator is Ownable {
         for (uint256 i = 0; i < transactions.length; i++) {
             Transaction storage t = transactions[i];
             if (t.enabled) {
-                bool result = t.destination.call(t.data);
+                (bool result, bytes memory reason) = t.destination.call(t.data);
                 if (!result) {
                     emit TransactionFailed(t.destination, i, t.data);
                     revert("Transaction Failed");

--- a/contracts/Orchestrator.sol
+++ b/contracts/Orchestrator.sol
@@ -16,8 +16,6 @@ contract Orchestrator is Ownable {
         bytes data;
     }
 
-    event TransactionFailed(address indexed destination, uint256 index, bytes data);
-
     // Stable ordering is not guaranteed.
     Transaction[] public transactions;
 


### PR DESCRIPTION
## Overview
Replacing custom externalCall function with the native solidity .call. With older versions of solidity (0.4.24) inline assembly is used to make external function calls. Now solidity supports [external function calls](https://docs.soliditylang.org/en/v0.6.1/control-structures.html#external-function-calls). Removing the externalCall function because it is not being used in the repo. Let me know if I should keep the externalCall function.

Based on the documentation, .call returns a boolean and bytes of memory.
`<address>.call(bytes memory) returns (bool, bytes memory)`

## Changes
- [x] Replace externalCall with .call
- [x] Remove externalCall function since it is not being used anywhere 

## Reviewers
@nithinkrishna 